### PR TITLE
Add include for Arduino.h

### DIFF
--- a/src/Sodaq_DS3231.h
+++ b/src/Sodaq_DS3231.h
@@ -11,6 +11,7 @@
 #ifndef SODAQ_DS3231_H
 #define SODAQ_DS3231_H
 
+#include <Arduino.h>
 #include <stdint.h>
 
 


### PR DESCRIPTION
If Sodaq_DS3231.h is included in a library, it needs to have String defined before.